### PR TITLE
2025-01-31 revisions

### DIFF
--- a/src/data/crew.js
+++ b/src/data/crew.js
@@ -54,9 +54,9 @@ const crew = {
           imageAlt: "Alex Feldman, Chief Pilot, CFI-I, and MEI of LA Flight Academy",
         },
         {
-          name: `Cameron Diamond<br><small class="text-white font-normal text-sm">Asst Chief Pilot, CFI, MEI</small>`,
+          name: `Cameron Diamond<br><small class="text-white font-normal text-sm">Asst Chief Pilot, CFI-I, MEI</small>`,
           imagePath: "/src/assets/lafa-headshot-of-cfi-cameron-diamond.jpg",
-          imageAlt: "Cameron Diamond, CFI at LA Flight Academy",
+          imageAlt: "Cameron Diamond, Asst Chief Pilot, CFI-I, MEI at LA Flight Academy",
         },
         {
           name: `Parker Capp<br><small class="text-white font-normal text-sm">CFI</small>`,
@@ -89,9 +89,9 @@ const crew = {
           imageAlt: "Andre Dassin, CFI at LA Flight Academy",
         },
         {
-          name: `Mason Morrow<br><small class="text-white font-normal text-sm">CFI</small>`,
+          name: `Mason Morrow<br><small class="text-white font-normal text-sm">CFI-I</small>`,
           imagePath: "/src/assets/lafa-headshot-of-cfi-mason-morrow.jpg",
-          imageAlt: "Mason Morrow, CFI at LA Flight Academy",
+          imageAlt: "Mason Morrow, CFI-I at LA Flight Academy",
         },
       ],
     },

--- a/src/data/fleetComp.js
+++ b/src/data/fleetComp.js
@@ -55,7 +55,7 @@ const fleetCompData = {
         "1999 Cessna 172S",
         "180hp — Fuel Injected",
         "Garmin 750 Touchpad GPS with Bluetooth Flightstream",
-        "Dual G5's (Altitude Indicator & Directional Gyro)",
+        "Dual G5's (Attitude Indicator & Directional Gyro)",
         "Autopilot",
         "IFR Certified",
         "Ideal for Instrument, Commercial and CFI Training",

--- a/src/data/fleetComp.js
+++ b/src/data/fleetComp.js
@@ -55,7 +55,7 @@ const fleetCompData = {
         "1999 Cessna 172S",
         "180hp — Fuel Injected",
         "Garmin 750 Touchpad GPS with Bluetooth Flightstream",
-        "Dual G5's (Attitude Indicator & Directional Gyro)",
+        "Dual G5's (Altitude Indicator & Directional Gyro)",
         "Autopilot",
         "IFR Certified",
         "Ideal for Instrument, Commercial and CFI Training",

--- a/src/data/fleetComp.js
+++ b/src/data/fleetComp.js
@@ -55,7 +55,7 @@ const fleetCompData = {
         "1999 Cessna 172S",
         "180hp — Fuel Injected",
         "Garmin 750 Touchpad GPS with Bluetooth Flightstream",
-        "G5 Directional Gyro",
+        "Dual G5's (Attitude Indicator & Directional Gyro)",
         "Autopilot",
         "IFR Certified",
         "Ideal for Instrument, Commercial and CFI Training",
@@ -83,10 +83,10 @@ const fleetCompData = {
       name: "N7901C",
       rates: "($175hr/$165 block)",
       description:
-        "This Piper Archer 2 PA28-181 is a four seat, 180HP, low wing aircraft that is ideal for Private Pilot, Instrument, Commercial and CFI Training.",
+        "This Piper Archer II PA28-181 is a four seat, 180HP, low wing aircraft that is ideal for Private Pilot, Instrument, Commercial and CFI Training.",
       image: "/src/assets/lafa-plane-piper-archer-outside-hangar.jpg",
       details: [
-        "1975 Piper Archer 2 PA28-181",
+        "1975 Piper Archer II PA28-181",
         "180hp Carbureted",
         "Garmin 430 GPS",
         "Dual VOR’s and Comm’s",
@@ -103,7 +103,7 @@ const fleetCompData = {
         "This Piper Archer II is a reliable and versatile piston-single aircraft, ideal for Private Pilot and Time-Building training. Manufactured in 1978.",
       image: "/src/assets/lafa-plane-piper-cherokee-outside-hangar.jpg",
       details: [
-        "1978 Piper Archer II PA28",
+        "1978 Piper Archer II PA28-181",
         "180hp — Piston-Single",
         "Garmin GNS430 GPS",
         "Traditional Round-Gauge Panel",
@@ -114,13 +114,13 @@ const fleetCompData = {
       ],
     },
     {
-      name: "N8165R",
+      name: "N8156R",
       rates: "($165HR/$155 block)",
       description:
         "This Piper Warrior II is a reliable and versatile piston-single aircraft, ideal for Private Pilot and Time-Building training. Manufactured in 1979.",
       image: "/src/assets/lafa-plane-piper-warrior-ii-outside-hangar.jpg",
       details: [
-        "1979 Piper Warrior II (PA28)",
+        "1979 Piper Warrior II PA28-161",
         "160hp — Piston-Single",
         "Garmin GNS430 GPS",
         "Traditional Round-Gauge Panel",

--- a/src/data/multiEngine.js
+++ b/src/data/multiEngine.js
@@ -49,10 +49,10 @@ const multiEngineRating = {
           title: "Meet Eligibility Requirements",
           paragraphs: [
             "To begin training, you must hold a valid Private Pilot License (PPL) or higher. Instrument proficiency is recommended to enhance your training experience, although it is not required.",
-            "We also recommend having logged time in complex aircraft or higher-performance planes to familiarize yourself with advanced flight systems.",
+            "Training in our Beechcraft Baron allows you to earn your Multi-Engine rating, Complex endorsement, and High-Performance endorsement—all in one. Unlike many twin-engine trainers with lower horsepower, our Baron’s 260 HP per engine ensures you meet high-performance aircraft requirements while gaining valuable multi-engine experience.",
           ],
           imagePath: "/src/assets/lafa-plane-beechcraft-twin-engine-outside-hangar.jpg",
-          imageAlt: "Pilot reviewing logbook for multi-engine eligibility",
+          imageAlt: "LAFA plane, Beechcraft Twin-Engine outside hangar at KVNY",
         },
         {
           title: "Ground School Training",
@@ -67,7 +67,7 @@ const multiEngineRating = {
           title: "Flight Training in Multi-Engine Aircraft",
           paragraphs: [
             "You’ll conduct hands-on training in one of our multi-engine aircraft, such as the Piper Seminole, gaining experience with advanced systems like twin-engine performance, variable pitch propellers, and retractable gear.",
-            "Our instructors will guide you through critical maneuvers, including engine-out procedures, Vmc demonstrations, and precision landings, ensuring you’re confident in the cockpit of a twin-engine aircraft.",
+            "Our instructors will guide you through critical maneuvers, including engine-out procedures, VMC demonstrations, and precision landings, ensuring you’re confident in the cockpit of a twin-engine aircraft.",
           ],
           imagePath: "/src/assets/lafa-flight-lesson.jpg",
           imageAlt: "Instructor and student flying a multi-engine aircraft",


### PR DESCRIPTION
- [x] For FLEET description:
- - [x] N252SP: Replace "G5 Directional Gyro" with "Dual G5's (Attitude Indicator & Directional Gyro)"
- - [x] N7901C: Change Archer 2 to Archer II
- - [x] N4313F: Change PA28 to PA28-181
- - [x] N8156R: Change PA28 to PA28-161
- [x] For Flight Instructors:
- - [x] Mason Morrow is a CFI-I
- - [x] Cameron CFI-I, MEI
- [x] Courses -- Multi-Engine -- 
- - [x] Meet Eligibility Requirements -- We also recommend having logged time in Complex and High-Performance...: This needs to change because what our multi engine students get by flying our Baron is their Complex rating, high performance because it's over 200 hp per engine (260hp) and of course their multi-engine rating. So these 3 should be the selling point for flying our Baron. Very few schools have twin engine planes and if they do, they're below 200+ hp so the students can't get their high performance. So maybe rephrase that to something like "Get your Complex rating, High-Performance and Multi-Engine license all-in-one.
- - [x] Change Vmc to VMC
