### PR TITLE
Cirrus Pics Update - June 2025

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,11 @@
+{
+  "cSpell.words": [
+    "Avidyne",
+    "BATD",
+    "Beechcraft",
+    "Flightstream",
+    "Gleim",
+    "LAFA",
+    "Nuys"
+  ]
+}

--- a/src/components/FleetCard.astro
+++ b/src/components/FleetCard.astro
@@ -15,17 +15,19 @@ const allImages = import.meta.glob<{ default: ImageMetadata }>(
   <div class="lg:w-1/2 w-full h-64 lg:h-full relative">
     <div class="swiper fleet-swiper h-full">
       <div class="swiper-wrapper h-full">
-        {images.map((imgPath) => (
-          <div class="swiper-slide h-full">
-            <Image
-              src={allImages[imgPath]()}
-              alt={`${name} photo`}
-              widths={[540, 720, 1080, 1440]}
-              sizes="(max-width: 768px) 100vw, 50vw"
-              class="w-full h-full object-cover"
-            />
-          </div>
-        ))}
+        {
+          images.map((imgPath) => (
+            <div class="swiper-slide h-full">
+              <Image
+                src={allImages[imgPath]()}
+                alt={`${name} photo`}
+                widths={[720, 1080, 1440]}
+                sizes="(max-width: 768px) 100vw, 50vw"
+                class="w-full h-full object-cover"
+              />
+            </div>
+          ))
+        }
       </div>
       <!-- Arrows inside image -->
       <div class="swiper-button-prev"></div>
@@ -34,7 +36,9 @@ const allImages = import.meta.glob<{ default: ImageMetadata }>(
   </div>
 
   <!-- Details -->
-  <div class="lg:w-1/2 w-full flex flex-col justify-center p-6 h-auto lg:h-full">
+  <div
+    class="lg:w-1/2 w-full flex flex-col justify-center p-6 h-auto lg:h-full"
+  >
     <h3 class="text-4xl font-serif font-semibold text-gray-800">{name}</h3>
     <p class="text-gray-500 text-sm mb-4">{rates}</p>
     <ul class="list-disc list-inside space-y-2">

--- a/src/data/fleetComp.js
+++ b/src/data/fleetComp.js
@@ -10,7 +10,8 @@ const fleetCompData = {
     // Top Header
     header: {
       stars: true,
-      imagePath: "/src/assets/la-flight-academy-cirrus-plane-fleet-van-nuys-flight-training.jpg",
+      imagePath:
+        "/src/assets/la-flight-academy-cirrus-plane-fleet-van-nuys-flight-training.jpg",
       imageAlt: "Three LA Flight Academy aircraft on the patio",
       headerH1: `Our <br><span>FLEET</span>`,
       paragraph: `Our aircraft and simulator are carefully selected and professionally maintained to support every stage of your flight training journey. From Piper Warriors and Cessna 172s to a Cirrus SR20 GTS, Beechcraft multi-engine, and our FAA-approved Gleim BATD simulator, LA Flight Academy offers the tools and technology to help you train efficiently and safely.`,
@@ -35,6 +36,7 @@ const fleetCompData = {
       images: [
         "/src/assets/Cirrus-219EL-fleet-pic.jpg",
         "/src/assets/Cirrus_interior.jpg",
+        "/src/assets/Cirrus-219EL-(1-of-1)-10.jpg",
         "/src/assets/la-flight-academy-cirrus-plane-fleet-van-nuys-flight-training.jpg",
       ],
       details: [
@@ -98,12 +100,10 @@ const fleetCompData = {
       rates: "($175hr/$165 block)",
       description:
         "This aircraft is ideal for Private Pilot, Commercial, CFI and Spin Training.",
-      images: [
-        "/src/assets/N76015_new.jpg",
-      ],
+      images: ["/src/assets/N76015_new.jpg"],
       details: [
         "1976 Cessna 172N",
-        "160hp Carbureted",
+        "160hp Carburetted",
         "Dual VOR’s and Comm’s",
         "IFR Certified",
         "Garmin 750 Touchpad GPS w/Bluetooth Flightstream",
@@ -117,12 +117,10 @@ const fleetCompData = {
       rates: "($185HR/$175 block)",
       description:
         "This Piper Warrior II is a reliable and versatile piston-single aircraft, ideal for Private Pilot and Time-Building training. Manufactured in 1979.",
-      images: [
-        "/src/assets/N42982-piper-archer.webp",
-      ],
+      images: ["/src/assets/N42982-piper-archer.webp"],
       details: [
         "1983 Piper Archer II",
-        "180hp Carbureted",
+        "180hp Carburetted",
         "Garmin 650 and Garmin 355 GPS with Dual G5s",
         "3 Axis Autopilot",
         "Technically Advanced Aircraft",
@@ -137,12 +135,10 @@ const fleetCompData = {
       rates: "($175hr/$165 block)",
       description:
         "This Piper Archer II PA28-181 is a four seat, 180HP, low wing aircraft that is ideal for Private Pilot, Instrument, Commercial and CFI Training.",
-      images: [
-        "/src/assets/N7901C_new.jpg",
-      ],
+      images: ["/src/assets/N7901C_new.jpg"],
       details: [
         "1975 Piper Archer II PA28-181",
-        "180hp Carbureted",
+        "180hp Carburetted",
         "Garmin 430 GPS",
         "Dual VOR’s and Comm’s",
         "IFR Certified",
@@ -156,9 +152,7 @@ const fleetCompData = {
       rates: "($175HR/$165 block)",
       description:
         "This Piper Archer II is a reliable and versatile piston-single aircraft, ideal for Private Pilot and Time-Building training. Manufactured in 1978.",
-      images: [
-        "/src/assets/N4313F_new.jpg",
-      ],
+      images: ["/src/assets/N4313F_new.jpg"],
       details: [
         "1978 Piper Archer II PA28-181",
         "180hp — Piston-Single",
@@ -175,9 +169,7 @@ const fleetCompData = {
       rates: "($165HR/$155 block)",
       description:
         "This Piper Warrior II is a reliable and versatile piston-single aircraft, ideal for Private Pilot and Time-Building training. Manufactured in 1979.",
-      images: [
-        "/src/assets/N8156R_new.jpg",
-      ],
+      images: ["/src/assets/N8156R_new.jpg"],
       details: [
         "1979 Piper Warrior II PA28-161",
         "160hp — Piston-Single",


### PR DESCRIPTION
This pull request introduces several updates related to spelling corrections, formatting improvements, and adjustments to the fleet data for an aviation-themed application. The most important changes include adding custom spelling terms to the VS Code settings, modifying image widths and formatting in the `FleetCard` component, and refining fleet data entries for consistency and accuracy.

### VS Code Configuration Updates:
* [`.vscode/settings.json`](diffhunk://#diff-a5de3e5871ffcc383a2294845bd3df25d3eeff6c29ad46e3a396577c413bf357R1-R11): Added custom spelling terms such as "Avidyne," "Beechcraft," and "Nuys" to the `cSpell.words` array for improved spell-checking during development.

### Component Updates:
* [`src/components/FleetCard.astro`](diffhunk://#diff-5c129b129894a2c7425053a362da4358d6c7cded02d26d6b3a79bbdfdbd23e5eL18-R30): Adjusted image widths in the `Image` component from `[540, 720, 1080, 1440]` to `[720, 1080, 1440]` for better responsiveness. Also reformatted JSX code for improved readability. [[1]](diffhunk://#diff-5c129b129894a2c7425053a362da4358d6c7cded02d26d6b3a79bbdfdbd23e5eL18-R30) [[2]](diffhunk://#diff-5c129b129894a2c7425053a362da4358d6c7cded02d26d6b3a79bbdfdbd23e5eL37-R41)

### Fleet Data Refinements:
* `src/data/fleetComp.js`: 
  - Corrected the spelling of "Carbureted" to "Carburetted" across multiple fleet entries for consistency. [[1]](diffhunk://#diff-7f4d3faa886dbb180d2c980a8a23691ffc43fd1d7879e7c6427efc2c5850a49eL101-R106) [[2]](diffhunk://#diff-7f4d3faa886dbb180d2c980a8a23691ffc43fd1d7879e7c6427efc2c5850a49eL120-R123) [[3]](diffhunk://#diff-7f4d3faa886dbb180d2c980a8a23691ffc43fd1d7879e7c6427efc2c5850a49eL140-R141)
  - Reformatted single-image arrays to inline format for cleaner code. [[1]](diffhunk://#diff-7f4d3faa886dbb180d2c980a8a23691ffc43fd1d7879e7c6427efc2c5850a49eL101-R106) [[2]](diffhunk://#diff-7f4d3faa886dbb180d2c980a8a23691ffc43fd1d7879e7c6427efc2c5850a49eL120-R123) [[3]](diffhunk://#diff-7f4d3faa886dbb180d2c980a8a23691ffc43fd1d7879e7c6427efc2c5850a49eL140-R141) [[4]](diffhunk://#diff-7f4d3faa886dbb180d2c980a8a23691ffc43fd1d7879e7c6427efc2c5850a49eL159-R155) [[5]](diffhunk://#diff-7f4d3faa886dbb180d2c980a8a23691ffc43fd1d7879e7c6427efc2c5850a49eL178-R172)
  - Added a new image to the `images` array for one of the fleet entries.